### PR TITLE
fix: add ref-based guard for recording race conditions in RehearsalRoom and CandidateInterview

### DIFF
--- a/frontend/src/pages/CandidateInterview.tsx
+++ b/frontend/src/pages/CandidateInterview.tsx
@@ -49,6 +49,7 @@ const CandidateInterview: React.FC = () => {
 	const mediaRecorderRef = useRef<MediaRecorder | null>(null);
 	const audioChunksRef = useRef<Blob[]>([]);
 	const timerIntervalRef = useRef<NodeJS.Timeout | null>(null);
+	const isMovingNext = useRef(false);
 
 	useEffect(() => {
 		if (!token) {
@@ -148,6 +149,10 @@ const CandidateInterview: React.FC = () => {
 					if (e.data?.size > 0) audioChunksRef.current.push(e.data);
 				};
 				mediaRecorder.onstop = async () => {
+					if (isMovingNext.current) {
+						isMovingNext.current = false;
+						return;
+					}
 					const blob = new Blob(audioChunksRef.current, { type: "audio/webm" });
 					await handleEvaluate(blob);
 				};
@@ -194,6 +199,7 @@ const CandidateInterview: React.FC = () => {
 
 	const handleNext = async () => {
 		if (speaking) stop();
+		isMovingNext.current = true;
 		if (isRecording) {
 			if (mediaRecorderRef.current?.state !== "inactive")
 				mediaRecorderRef.current?.stop();
@@ -211,6 +217,7 @@ const CandidateInterview: React.FC = () => {
 			// All questions answered — submit results to backend
 			await submitAllResults();
 		}
+		isMovingNext.current = false;
 	};
 
 	const submitAllResults = async () => {

--- a/frontend/src/pages/RehearsalRoom.tsx
+++ b/frontend/src/pages/RehearsalRoom.tsx
@@ -61,6 +61,7 @@ const RehearsalRoom: React.FC = () => {
 	const mediaRecorderRef = useRef<MediaRecorder | null>(null);
 	const audioChunksRef = useRef<Blob[]>([]);
 	const timerIntervalRef = useRef<NodeJS.Timeout | null>(null);
+	const isMovingNext = useRef(false);
 
 	const startInterview = async (role: string) => {
 		setTargetRole(role);
@@ -144,6 +145,10 @@ const RehearsalRoom: React.FC = () => {
 					if (e.data?.size > 0) audioChunksRef.current.push(e.data);
 				};
 				mediaRecorder.onstop = async () => {
+					if (isMovingNext.current) {
+						isMovingNext.current = false;
+						return;
+					}
 					const blob = new Blob(audioChunksRef.current, { type: "audio/webm" });
 					await handleEvaluate(blob);
 				};
@@ -205,6 +210,7 @@ const RehearsalRoom: React.FC = () => {
 
 	const handleNext = async () => {
 		if (speaking) stop();
+		isMovingNext.current = true;
 		if (isRecording) {
 			if (mediaRecorderRef.current?.state !== "inactive")
 				mediaRecorderRef.current?.stop();
@@ -223,6 +229,7 @@ const RehearsalRoom: React.FC = () => {
 			if (answered.length === 0) navigate("/dashboard");
 			else await handleFinishSession(answered);
 		}
+		isMovingNext.current = false;
 	};
 
 	useEffect(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses a race condition in the `RehearsalRoom` and `CandidateInterview` pages where the `mediaRecorder.onstop` event could trigger an audio evaluation (`handleEvaluate`) even when the user was actively navigating to the next question or finishing the session.

The changes introduce a new `isMovingNext` ref to act as a guard:
- When the `handleNext` function is called, `isMovingNext` is set to `true`.
- The `mediaRecorder.onstop` event handler now checks this flag. If `isMovingNext` is `true`, the audio evaluation is skipped, preventing an unwanted or erroneous evaluation during navigation.
- `isMovingNext` is reset to `false` once the `handleNext` logic is completed.

This ensures that audio recordings are only evaluated when the recording genuinely stops as part of the intended flow, preventing conflicts and potential errors during page transitions.
<!-- kody-pr-summary:end -->