### PR TITLE
fix: add missing patch method to API client

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -43,5 +43,6 @@ export const api = {
   get: <T>(path: string, opts?: RequestOptions) => request<T>(path, opts),
   post: <T>(path: string, body?: any, opts?: RequestOptions) => request<T>(path, { ...opts, method: "POST", body }),
   put: <T>(path: string, body?: any, opts?: RequestOptions) => request<T>(path, { ...opts, method: "PUT", body }),
+  patch: <T>(path: string, body?: any, opts?: RequestOptions) => request<T>(path, { ...opts, method: "PATCH", body }),
   delete: <T>(path: string, body?: any, opts?: RequestOptions) => request<T>(path, { ...opts, method: "DELETE", body }),
 };


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Adds a `patch` method to the frontend API client, enabling the application to send HTTP PATCH requests for partial updates to resources.
<!-- kody-pr-summary:end -->